### PR TITLE
chore: modernize Terraform and provider versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,17 +130,17 @@ module "mod_vnp" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
-| <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
+| <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.116 |
 
 ## Modules
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -130,17 +130,17 @@ module "mod_vnp" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.22 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.22 |
-| <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.22 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
+| <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.116 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,11 +2,11 @@
 # Licensed under the MIT License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.9"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.22"
+      version = "~> 3.116"
     }
     azurenoopsutils = {
       source  = "azurenoops/azurenoopsutils"


### PR DESCRIPTION
## Summary

Modernize version constraints to current standards.

### Changes
- Terraform `>= 1.3` → `>= 1.9`
- azurerm `~> 3.22` → `~> 3.116`
- azurenoopsutils → `~> 1.0.4`
- Updated examples and documentation

Closes #10