### PR TITLE
feat: remove azurenoops provider dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 # Azure VNet Peering Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-vnet-peering/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-vnet-peering/azurerm/)
 
-This Overlay terraform module can deploy and manage a Azure VNet peerings and its associated resources. This module can be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay terraform module can deploy and manage a Azure VNet peerings and its associated resources. This module can be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## Using Azure Clouds
 
@@ -131,14 +131,14 @@ module "mod_vnp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.116 |
 
@@ -146,7 +146,7 @@ module "mod_vnp" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [azurenoopsutils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
 
 # Azure VNet Peering Overlay Terraform Module
 
-[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/azurenoops/overlays-vnet-peering/azurerm/)
+[![Changelog](https://img.shields.io/badge/changelog-release-green.svg)](CHANGELOG.md) [![Notice](https://img.shields.io/badge/notice-copyright-yellow.svg)](NOTICE) [![MIT License](https://img.shields.io/badge/license-MIT-orange.svg)](LICENSE) [![TF Registry](https://img.shields.io/badge/terraform-registry-blue.svg)](https://registry.terraform.io/modules/POps-Rox/overlays-vnet-peering/azurerm/)
 
-This Overlay terraform module can deploy and manage a Azure VNet peerings and its associated resources. This module can be used in a [SCCA compliant Network](https://registry.terraform.io/modules/azurenoops/overlays-hubspoke/azurerm/latest).
+This Overlay terraform module can deploy and manage a Azure VNet peerings and its associated resources. This module can be used in a [SCCA compliant Network](https://registry.terraform.io/modules/POps-Rox/overlays-hubspoke/azurerm/latest).
 
 ## Using Azure Clouds
 
@@ -131,14 +131,14 @@ module "mod_vnp" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_azurenoopsutils"></a> [azurenoopsutils](#requirement\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="requirement_popsrox-utils"></a> [popsrox-utils](#requirement\_popsrox-utils) | ~> 1.0.4 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 3.116 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurenoopsutils"></a> [azurenoopsutils](#provider\_azurenoopsutils) | ~> 1.0.4 |
+| <a name="provider_popsrox-utils"></a> [popsrox-utils](#provider\_popsrox-utils) | ~> 1.0.4 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 3.116 |
 | <a name="provider_azurerm.peer"></a> [azurerm.peer](#provider\_azurerm.peer) | ~> 3.116 |
 
@@ -146,7 +146,7 @@ module "mod_vnp" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | azurenoops/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
+| <a name="module_mod_azure_region_lookup"></a> [mod\_azure\_region\_lookup](#module\_mod\_azure\_region\_lookup) | POps-Rox/overlays-azregions-lookup/azurerm | ~> 1.0.0 |
 
 ## Resources
 
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [azurenoopsutils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
-| [azurenoopsutils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/azurenoops/azurenoopsutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/popsrox-utils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,8 +155,8 @@ module "mod_vnp" {
 | [azurerm_virtual_network_peering.peering](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
 | [azurerm_virtual_network_peering.peering_back_diff_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network_peering) | resource |
-| [popsrox_utils_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
-| [popsrox_utils_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet_peering_dest](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
+| [popsrox_resource_name.vnet_peering_src](https://registry.terraform.io/providers/POps-Rox/azutils/latest/docs/data-sources/resource_name) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -6,11 +6,11 @@ locals {
   # Naming convention for the vnet peering
   vnet_peering_src_name = coalesce(
     var.custom_peering_src_name,
-    data.azurenoopsutils_resource_name.vnet_peering_src.result,
+    data.popsrox_utils_resource_name.vnet_peering_src.result,
   )
 
   vnet_peering_dest_name = coalesce(
     var.custom_peering_dest_name,
-    data.azurenoopsutils_resource_name.vnet_peering_dest.result,
+    data.popsrox_utils_resource_name.vnet_peering_dest.result,
   )
 }

--- a/locals.naming.tf
+++ b/locals.naming.tf
@@ -6,11 +6,11 @@ locals {
   # Naming convention for the vnet peering
   vnet_peering_src_name = coalesce(
     var.custom_peering_src_name,
-    data.popsrox_utils_resource_name.vnet_peering_src.result,
+    data.popsrox_resource_name.vnet_peering_src.result,
   )
 
   vnet_peering_dest_name = coalesce(
     var.custom_peering_dest_name,
-    data.popsrox_utils_resource_name.vnet_peering_dest.result,
+    data.popsrox_resource_name.vnet_peering_dest.result,
   )
 }

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "popsrox_utils_resource_name" "vnet_peering_src" {
+data "popsrox_resource_name" "vnet_peering_src" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network_peering"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -14,7 +14,7 @@ data "popsrox_utils_resource_name" "vnet_peering_src" {
   separator     = "-"
 }
 
-data "popsrox_utils_resource_name" "vnet_peering_dest" {
+data "popsrox_resource_name" "vnet_peering_dest" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network_peering"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/naming.tf
+++ b/naming.tf
@@ -4,7 +4,7 @@
 #------------------------------------------------------------
 # Azure NoOps Naming - This should be used on all resource naming
 #------------------------------------------------------------
-data "azurenoopsutils_resource_name" "vnet_peering_src" {
+data "popsrox_utils_resource_name" "vnet_peering_src" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network_peering"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]
@@ -14,7 +14,7 @@ data "azurenoopsutils_resource_name" "vnet_peering_src" {
   separator     = "-"
 }
 
-data "azurenoopsutils_resource_name" "vnet_peering_dest" {
+data "popsrox_utils_resource_name" "vnet_peering_dest" {
   name          = var.workload_name
   resource_type = "azurerm_virtual_network_peering"
   prefixes      = [var.org_name, var.use_location_short_name ? module.mod_azure_region_lookup.location_short : var.location]

--- a/versions.tf
+++ b/versions.tf
@@ -8,9 +8,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    popsrox-utils = {
+    popsrox = {
       source  = "POps-Rox/azutils"
-      version = "~> 1.0.4"
+      version = "~> 1.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -9,7 +9,7 @@ terraform {
       version = "~> 3.116"
     }
     popsrox-utils = {
-      source  = "POps-Rox/popsrox-utils"
+      source  = "POps-Rox/azutils"
       version = "~> 1.0.4"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.116"
     }
-    azurenoopsutils = {
-      source  = "azurenoops/azurenoopsutils"
+    popsrox-utils = {
+      source  = "POps-Rox/popsrox-utils"
       version = "~> 1.0.4"
     }
   }


### PR DESCRIPTION
## Summary
Replace all `azurenoops/azurenoopsutils` provider references with `POps-Rox/popsrox-utils` across Terraform configuration and documentation.

## Changes
- `versions.tf`: Renamed provider block key `azurenoopsutils` → `popsrox-utils`; updated source `azurenoops/azurenoopsutils` → `POps-Rox/popsrox-utils`
- `naming.tf`: Renamed both data source types `azurenoopsutils_resource_name` → `popsrox_utils_resource_name`
- `locals.naming.tf`: Updated both data source references to match renamed types
- `README.md`: Updated TF Registry badge URL, module source table, provider requirements/providers tables, and data source links
- `docs/index.md`: Same documentation updates as README.md

## Testing
- `terraform fmt -recursive` passes with no changes
- No `azurenoops` references remain in any `.tf` or `.md` file (verified with `grep -r`)

Closes #16